### PR TITLE
Typings Update pt 6969

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,27 +1,31 @@
-import { Socket } from 'net';
-
 declare module 'discord-urpc' {
-    export class DiscordRPC {
+    import { Socket } from 'net';
+    import { EventEmitter } from 'events';
+    
+    export class DiscordRPC extends EventEmitter {
         constructor(info: DiscordRPCInfo);
 
         public discordIPC: DiscordIPC;
         public send(command: string, args?: any): void;
+        public on(event: 'ready', listener: () => void): this;
     }
 
-    export class DiscordIPC {
+    export class DiscordIPC extends EventEmitter {
         constructor(clientID: string);
 
         public clientID: string;
         public socket: Socket | null;
         public connect(): Promise<void>;
-        public onClise(e: any): void;
+        public onClose(e: any): void;
         public send(pkt: any, op: number): void;
         public close(): void;
-
+        public on(event: 'open', listener: () => void): this;
+        public on(event: 'error', listener: (event: any) => void): this;
+        public on(event: 'close', listener: (event: any) => void): this;
     }
 
     export interface DiscordRPCInfo {
         clientID: string;
-        debug?: boolean;
+        debug: boolean;
     }
 }


### PR DESCRIPTION
# Updated

- Added the `EventEmitter` extension to DiscordRPC and DiscordRPC
- Added the events to the EventEmitter extensions from the present code
- Made `debug` not optional
- Fixed an error on the imports (TypeScript declarations is fucking weird without namespaces)